### PR TITLE
Fix curricula for eng at Cesena

### DIFF
--- a/timetables.json
+++ b/timetables.json
@@ -2,64 +2,61 @@
   "l_informatica": {
     "course": "Informatica",
     "type": "laurea",
-    "name": "informatica",
-    "url": "orario-lezioni"
+    "name": "informatica"
   },
   "l_informaticamanagement": {
     "course": "Informatica per il Management",
     "type": "laurea",
-    "name": "InformaticaManagement",
-    "url": "orario-lezioni"
+    "name": "InformaticaManagement"
   },
   "l_ingegneriainformatica": {
     "course": "Ingegneria Informatica",
     "type": "laurea",
-    "name": "ingegneriainformatica",
-    "url": "orario-lezioni"
+    "name": "ingegneriainformatica"
   },
   "l_ingegneriascienceinformatiche": {
     "course": "Ingegneria e Scienze Informatiche",
     "type": "laurea",
-    "name": "IngegneriaScienzeInformatiche",
-    "url": "orario-lezioni"
+    "name": "IngegneriaScienzeInformatiche"
   },
   "lm_informatica_software_techniques": {
     "course": "Informatica magistrale - Tecniche del software",
     "type": "magistrale",
     "name": "informatica",
-    "curricula": "A58-000",
-    "url": "orario-lezioni"
+    "curricula": "A58-000"
   },
   "lm_informatica_management": {
     "course": "Informatica magistrale - Informatica per il management",
     "type": "magistrale",
     "name": "informatica",
-    "curricula": "991-000",
-    "url": "orario-lezioni"
+    "curricula": "991-000"
   },
   "lm_informatica_systems_and_networks": {
     "course": "Informatica magistrale - Sistemi e reti",
     "type": "magistrale",
     "name": "informatica",
-    "curricula": "992-000",
-    "url": "orario-lezioni"
+    "curricula": "992-000"
   },
   "lm_ingegneriascienzeinformatiche": {
     "course": "Ingegneria e Scienze Informatiche Magistrale",
     "type": "magistrale",
     "name": "IngegneriaScienzeInformatiche",
-    "url": "orario-lezioni"
+    "curricula": "C17-000"
+  },
+  "lm_intelligent_systems": {
+    "course": "Intelligent Embedded Systems",
+    "type": "magistrale",
+    "name": "IngegneriaScienzeInformatiche",
+    "curricula": "000-000"
   },
   "lm_ingegneriainformatica": {
-    "course": "Ingegneria e Scienze Informatiche Magistrale",
+    "course": "Ingegneria Informatica Magistrale",
     "type": "magistrale",
-    "name": "ingegneriainformatica",
-    "url": "orario-lezioni"
+    "name": "ingegneriainformatica"
   },
   "lm_ai": {
     "course": "Artificial Intelligence",
     "type": "2cycle",
-    "name": "artificial-intelligence",
-    "url": "timetable"
+    "name": "artificial-intelligence"
   }
 }


### PR DESCRIPTION
Nell'ultima PR ho aggiunto anche la magistrale di Cesena, ma abbiam dimenticato che alla magistrale hanno 2 curricula, quindi la ricerca non avviene senza quel filtro :\
Inoltre ho sistemato il testo per "Ingegneria informatica magistrale" e rimosso `url` visto che, alla fine, non serve :)