### PR TITLE
tolte virgolette nel campo id dei mantainers

### DIFF
--- a/mantainers.json
+++ b/mantainers.json
@@ -3,15 +3,15 @@
         "project":"informabot",
         "mantainers": [
             {
-                "Id":"344994427",
+                "Id":344994427,
                 "Username":"Tastier"
             },
             {
-                "Id":"1078074095",
+                "Id":1078074095,
                 "Username":"f_o_x_y_s_e_t_a"
             },
             {
-                "Id":"948678601",
+                "Id":948678601,
                 "Username":"alii_benatti"
             }
         ]


### PR DESCRIPTION
Questo serve per il parse del json che altrimenti legge una stringa al posto di un int64

Le modifiche al parse del json sono nell'altra PR (informabot/tag_mantainer)