### PR TITLE
feat: Typst

### DIFF
--- a/.github/workflows/statik.yml
+++ b/.github/workflows/statik.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Recursively compile xopp files
         run: rec "\.xopp$" /usr/bin/xopp2pdf
 
+      - name: Recursively compile typ files
+        run: rec "\.typ$" "typst compile"
+
       - name: Generate static directory listing
         run: >
           statik


### PR DESCRIPTION
Closes #46.
Add files Typst support in the `statik.yml` pipeline.

Depends on https://github.com/csunibo/build-image/pull/8. Do not merge until that is accepted.