### PR TITLE
Add REUSE compliance check

### DIFF
--- a/.github/workflows/filenames.yaml
+++ b/.github/workflows/filenames.yaml
@@ -1,4 +1,4 @@
-name: Check filenames
+name: Materie CI
 on:
   workflow_call:
 
@@ -58,3 +58,14 @@ jobs:
 
       - name: Check the `misc` folder
         run: filenameslinter misc
+
+  reuse:
+    name: Check REUSE
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v5


### PR DESCRIPTION
Questa modifica fa si che tutti i repositori delle materie, che già chiamano questo workflow per controllare i nomi dei file, chiamino anche il tool di REUSE, per obbligare tutte le contribuzioni a specificare una licenza.

Ovviamente all'inizio avremo molti test rossi, ma l'idea è che nel tempo si possa fare sempre meglio.