### PR TITLE
Localization: `midterm` -> `partial-exam`

### DIFF
--- a/prove.synta
+++ b/prove.synta
@@ -17,6 +17,6 @@ mese = \d{2}
 tipo = testo|exam|soluzione|solution
 
 ; La tipologia del documento. Ad esempio: scritto, orale1, progetto2, totale.
-tipologia = scritto|written-test|totale|final|parziale\d|midterm\d|esercitazione\d?|simulation\d?|orale\d?|oral-test\d?|progetto\d?|project\d?|compito\d|homework\d
+tipologia = scritto|written-test|totale|final|parziale\d|partial-exam\d|esercitazione\d?|simulation\d?|orale\d?|oral-test\d?|progetto\d?|project\d?|compito\d|homework\d
 
 > tipologia-anno(-mese)?(-giorno)?(-extra)?-tipo(-extra)?.estensione


### PR DESCRIPTION
Most partial exams are not, in fact, midterms. For example, in a course with 3 modules, `exams/midterm3-2021-06-18-exam.pdf` seems to describe an exam taking place after the first half of the course. This is not the case, as students usually take the partial exam for module 3/3 at the end of the course. With this change, we ask contributors to name the same file as `exams/partial-exam3-2021-06-18-exam.pdf`. What do you think?